### PR TITLE
Basic RTC chat

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,7 +24,7 @@
     "react-dom": "^18.2.0",
     "react-query": "^3.39.3",
     "react-router-dom": "^6.16.0",
-    "react-split": "^2.0.14"
+    "socket.io-client": "^4.7.2"
   },
   "devDependencies": {
     "@types/react": "^18.2.15",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,6 +18,7 @@ import HomePage from './pages/HomePage';
 import ProblemPage from './pages/problems/ProblemPage';
 import QuestionsPage from './pages/QuestionsPage';
 import Loading from './components/Loading';
+import SocketChatPageTest from './pages/problems/SocketChatPageTest';
 
 function App() {
   const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
@@ -74,6 +75,8 @@ function App() {
               {session && (
                 <Routes>
                   <Route path="/" element={<HomePage />} />
+                  {/* TODO: REMOVE TEST PATH SOCKET */}
+                  <Route path="/socket" element={<SocketChatPageTest />} />
                   <Route path="/user" element={<UserPageMain />} />
                   <Route path="/user/:id" element={<UserProfilesPage />} />
                   <Route path="/questions" element={<QuestionsPage />} />

--- a/frontend/src/components/Chat/ChatBox.tsx
+++ b/frontend/src/components/Chat/ChatBox.tsx
@@ -1,5 +1,5 @@
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import { socket } from '../../socket.js';
 import {
   Stack
@@ -11,10 +11,16 @@ import { ChatDirections, ChatMessageType } from './types';
 
 const ChatBox = () => {
   const [messages, setMessages] = useState<ChatMessageType[]>([]);
+  const lastMessageRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     socket.on('messageResponse', (data) => setMessages([...messages, data]));
   }, [socket, messages]);
+
+  useEffect(() => {
+    // implement autoscroll when new messages come in
+    lastMessageRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
 
   return (
     <>
@@ -23,8 +29,8 @@ const ChatBox = () => {
         {messages.map(({ message, sender, createdAt }, _i) => {
           const direction = socket.auth.email == sender ? ChatDirections.left : ChatDirections.right;
           return (<ChatMessage message={message} direction={direction} sender={sender} createdAt={createdAt} />)
-        })
-        }
+        })}
+        <div ref={lastMessageRef} />
       </Stack>
     </>
   );

--- a/frontend/src/components/Chat/ChatBox.tsx
+++ b/frontend/src/components/Chat/ChatBox.tsx
@@ -1,0 +1,33 @@
+
+import { useEffect, useState } from 'react';
+import { socket } from '../../socket.js';
+import {
+  Stack
+} from '@mui/material';
+import { Chat } from '@mui/icons-material';
+import ChatMessage from './ChatMessage.tsx';
+
+import { ChatDirections, ChatMessageType } from './types';
+
+const ChatBox = () => {
+  const [messages, setMessages] = useState<ChatMessageType[]>([]);
+
+  useEffect(() => {
+    socket.on('messageResponse', (data) => setMessages([...messages, data]));
+  }, [socket, messages]);
+
+  return (
+    <>
+      <Stack spacing={1}>
+        <Chat /> Chat messages go here
+        {messages.map(({ message, sender, createdAt }, _i) => {
+          const direction = socket.auth.email == sender ? ChatDirections.left : ChatDirections.right;
+          return (<ChatMessage message={message} direction={direction} sender={sender} createdAt={createdAt} />)
+        })
+        }
+      </Stack>
+    </>
+  );
+};
+
+export default ChatBox;

--- a/frontend/src/components/Chat/ChatInputBox.tsx
+++ b/frontend/src/components/Chat/ChatInputBox.tsx
@@ -1,0 +1,48 @@
+
+import {
+  Box,
+  Button,
+  TextField,
+} from '@mui/material';
+import { useState } from 'react';
+import { socket } from '../../socket.js';
+
+const ChatInputBox = () => {
+  const [message, setMessage] = useState('');
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    console.log(`Submitting message: ${message}`);
+    console.log(socket.auth)
+    const name = socket.auth ? socket.auth.email : 'Anonymous' // should always have a user
+    if (message.length > 0) {
+      socket.emit('chat message', {
+        message: message,
+        sender: name,
+        createdAt: new Date()
+      });
+      setMessage('');
+    }
+  };
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setMessage(event.target.value);
+  };
+
+  return (
+    <Box component="form" onSubmit={handleSubmit}>
+      <TextField
+        id="message"
+        label="Message"
+        variant="outlined"
+        value={message}
+        onChange={handleChange}
+      />
+      <Button type="submit" variant="contained">
+        Send
+      </Button>
+    </Box>
+  );
+};
+
+export default ChatInputBox;

--- a/frontend/src/components/Chat/ChatMessage.tsx
+++ b/frontend/src/components/Chat/ChatMessage.tsx
@@ -1,0 +1,34 @@
+
+import {
+    Box,
+    Paper,
+    Typography
+} from '@mui/material';
+import { ChatDirections, ChatMessageProps } from './types';
+
+const ChatMessage = (props: ChatMessageProps) => {
+    return (
+        <Box
+            sx={{
+                display: "flex",
+                justifyContent: props.direction == ChatDirections.left ? "flex-start" : "flex-end",
+                mb: 2,
+            }}
+        >
+            <Paper
+                variant="outlined"
+                sx={{
+                    p: 2,
+                    backgroundColor: props.direction == ChatDirections.left ? "primary.light" : "secondary.light",
+                    borderRadius: props.direction == ChatDirections.left ? "20px 20px 20px 5px" : "20px 20px 5px 20px",
+                }}
+            >
+                <Typography variant="body1">{props.message}</Typography>
+                <Typography variant="body2">{props.sender}</Typography>
+                {props.createdAt ? props.createdAt.toString() : ''}
+            </Paper>
+        </Box>
+    );
+};
+
+export default ChatMessage;

--- a/frontend/src/components/Chat/types.ts
+++ b/frontend/src/components/Chat/types.ts
@@ -1,0 +1,17 @@
+export type ChatMessageType = {
+    message: string;
+    sender: string;
+    createdAt: Date;
+};
+
+export enum ChatDirections {
+    left,
+    right
+}
+
+export type ChatMessageProps = {
+    direction: ChatDirections;
+    message: string;
+    sender?: string;
+    createdAt?: Date;
+}

--- a/frontend/src/pages/problems/SocketChatPageTest.tsx
+++ b/frontend/src/pages/problems/SocketChatPageTest.tsx
@@ -14,6 +14,7 @@ const SocketChatPageTest = () => {
   const [isConnected, setIsConnected] = useState(socket.connected);
 
   const { user } = Auth.useUser();
+
   useEffect(() => {
     function onConnect() {
       setIsConnected(true);

--- a/frontend/src/pages/problems/SocketChatPageTest.tsx
+++ b/frontend/src/pages/problems/SocketChatPageTest.tsx
@@ -1,0 +1,98 @@
+import Playground from '../../components/Problems/Playground';
+import { Stack, Box, Paper } from '@mui/material';
+import ProblemDescription from '../../components/Problems/ProblemDescription';
+import { useEffect, useState } from 'react';
+import ChatBox from '../../components/Chat/ChatBox';
+import { socket } from '../../socket.js';
+import { Auth } from '@supabase/auth-ui-react';
+import ChatInputBox from '../../components/Chat/ChatInputBox';
+
+const SocketChatPageTest = () => {
+  // While this holds the UI components right now, this is a test component for
+  // an overarching socket "app". The useEffects are set up here and passed to 
+  // child components if necessary.
+  const [isConnected, setIsConnected] = useState(socket.connected);
+
+  const { user } = Auth.useUser();
+  useEffect(() => {
+    function onConnect() {
+      setIsConnected(true);
+    }
+
+    function onDisconnect() {
+      setIsConnected(false);
+    }
+
+    socket.on('connect', onConnect);
+    socket.on('disconnect', onDisconnect);
+
+    return () => {
+      socket.off('connect', onConnect);
+      socket.off('disconnect', onDisconnect);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (user) {
+      socket.auth = user
+      socket.connect();
+    }
+  }, [user]);
+  useEffect(() => {
+    const html = document.querySelector('html');
+    if (html) html.style.overflow = 'hidden';
+  }, []);
+
+  return (
+    <Box>
+      <Stack direction="row">
+        <Box>
+          connected to socket: {isConnected ? "True" : "False"}
+          <Paper sx={{
+            height: '30vh',
+            display: 'flex',
+            flexDirection: 'column',
+            overflow: 'hidden',
+            overflowY: 'scroll',
+            padding: '1em',
+            margin: '0.5em 0.25em 0.25em 0.5em'
+          }}>
+            <ChatBox />
+          </Paper>
+          <ChatInputBox />
+          <Paper
+            elevation={5}
+            sx={{
+              height: '50vh',
+              display: 'flex',
+              flexDirection: 'column',
+              overflow: 'hidden',
+              overflowY: 'scroll',
+              padding: '1em',
+              margin: '0.5em 0.25em 0.25em 0.5em'
+            }}
+          >
+            <ProblemDescription />
+          </Paper>
+        </Box>
+        <Paper
+          elevation={5}
+          sx={{
+            minWidth: '50%',
+            height: '90vh',
+            display: 'flex',
+            flexDirection: 'column',
+            overflow: 'hidden',
+            overflowY: 'scroll',
+            padding: '1em',
+            margin: '0.2em 0.5em 0.25em 0.25em'
+          }}
+        >
+          <Playground />
+        </Paper>
+      </Stack>
+    </Box>
+  );
+};
+
+export default SocketChatPageTest;

--- a/frontend/src/socket.js
+++ b/frontend/src/socket.js
@@ -1,0 +1,25 @@
+import { io } from 'socket.io-client';
+
+// "undefined" means the URL will be computed from the `window.location` object
+const URL = 'http://localhost:4000';
+// const URL = process.env.NODE_ENV === 'production' ? undefined : 'http://localhost:4000';
+
+export const socket = io(URL, {
+    withCredentials: true, // not sure if I need this
+    // Switch to this later and force validation before using it
+    autoConnect: false
+});
+
+socket.onAny((event, ...args) => {
+    console.log(event, args);
+});
+
+socket.on("connect_error", (err) => {
+    console.log(`connect_error due to ${err.message}`);
+});
+
+// in https://socket.io/get-started/private-messaging-part-1/#how-it-works 
+// it implies i should destroy it - where should this code go?
+// destroyed() {
+//     socket.off("connect_error");
+//   }

--- a/interview-service/index.ts
+++ b/interview-service/index.ts
@@ -1,0 +1,41 @@
+import express, { Application, Request, Response } from 'express';
+import httpPackage from 'http';
+import { Server } from 'socket.io';
+
+const app: Application = express();
+const PORT = process.env.PORT || 4000;
+
+//New imports
+const http = new httpPackage.Server(app);
+
+const socketIO = new Server(http, {
+  cors: {
+    origin: "http://localhost:5173",
+    credentials: true // not sure if needed; but if in the client need in server
+  },
+});
+
+socketIO.listen(4000)
+
+socketIO.on('connection', (socket) => {
+  console.log(`⚡: ${socket.id} user just connected!`);
+  // join a room. This one is a test to be able to broadcast messages
+  // TODO: Join the room based on the matching by matching service
+  socket.join("Test Room")
+
+  socket.on('disconnect', () => {
+    console.log('🔥: A user disconnected');
+  });
+
+  socket.on('chat message', (msg) => {
+    console.log('message: ' + socket.id + msg.message + msg.createdAt + msg.sender);
+    // send message to self
+    socket.emit('messageResponse', msg);
+    // send message to others
+    socket.to("Test Room").emit('messageResponse', msg);
+  });
+});
+
+app.get('/', (req: Request, res: Response) => {
+  res.send('Interview Service running');
+});

--- a/interview-service/package.json
+++ b/interview-service/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "interview-service",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.ts",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "npx tsc",
+    "start": "node dist/index.ts",
+    "dev": "nodemon index.ts"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.18.2",
+    "nodemon": "^3.0.1",
+    "socket.io": "^4.7.2"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.19",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.0.2"
+  }
+}

--- a/interview-service/tsconfig.json
+++ b/interview-service/tsconfig.json
@@ -1,0 +1,31 @@
+{
+  "compilerOptions": {
+    "target": "es2018",
+    "module": "nodenext",
+    "lib": ["dom", "es6", "es2018", "esnext.asynciterable"],
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "moduleResolution": "NodeNext",
+    "removeComments": true,
+    "strict": true,
+    "noImplicitThis": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "allowSyntheticDefaultImports": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "baseUrl": ".",
+    "declaration": true,
+    "incremental": true,
+    "noImplicitAny": false,
+    "forceConsistentCasingInFileNames": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts", "lib/*.ts"],
+  "exclude": ["**/node_modules", "dist"]
+}


### PR DESCRIPTION
To test:

* Log in (with different accounts)
* Navigate to /socket on the frontend
* Check that it is connected (should say true on the page)
* Typing message and hitting enter / pressing send should send to all open frontends

only connects if you're logged in. also shld autoscroll to most recent message

TODO (in future PRs):
* Sync this with the matching service so that only those matched in the same interview can talk to each other via chat
* Fix the look of the frontend, and rename / clean up names of components
* Ensure that you can't send messages until the other person connects in order to prevent the messages from being lost

NOTES/EXPLANATION
* The concept of rooms is only on the server so the communication with matching service should probably be there. right now it broadcasts essentially to all connected users
* i put the socket hooks on the socketchatpagetest - we could use federation to have a separate frontend for this as well but i think that's a bit overkill. anyway thought it would be cleaner to do it there rather than in the main app and keep passing down to the child props...